### PR TITLE
Change artifact name to apriltaglib, remove jni

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           java-version: 11
           architecture: ${{ matrix.architecture }}
       - name: Build with Gradle
-        run: ./gradlew build -Pbuildalldesktop
+        run: ./gradlew build
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.artifact-name }}

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'c'
     id 'cpp'
     id 'visual-studio'
-    id 'edu.wpi.first.NativeUtils' version '2023.9.1'
+    id 'edu.wpi.first.NativeUtils' version '2023.9.0'
     id 'edu.wpi.first.GradleVsCode' version '1.3.0'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'c'
     id 'cpp'
     id 'visual-studio'
-    id 'edu.wpi.first.NativeUtils' version '2023.9.0'
+    id 'edu.wpi.first.NativeUtils' version '2023.9.1'
     id 'edu.wpi.first.GradleVsCode' version '1.3.0'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,7 @@ plugins {
     id 'c'
     id 'cpp'
     id 'visual-studio'
-    id 'edu.wpi.first.NativeUtils' version '2023.3.0'
-    id 'edu.wpi.first.GradleJni' version '1.0.0'
+    id 'edu.wpi.first.NativeUtils' version '2023.9.0'
     id 'edu.wpi.first.GradleVsCode' version '1.3.0'
 }
 
@@ -41,7 +40,7 @@ nativeUtils {
 
 model {
     components {
-        apriltag(NativeLibrarySpec) {
+        apriltaglib(NativeLibrarySpec) {
             sources {
                 c {
                     source {
@@ -65,29 +64,10 @@ model {
                     }
                 }
             }
+            binaries.withType(SharedLibraryBinarySpec) {
+                buildable = false
+            }
             appendDebugPathToBinaries(binaries)
-        }
-        apriltagjni(JniNativeLibrarySpec) {
-            enableCheckTask true
-            jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.roborio)
-            // Leave these for future proofing
-            jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.linuxarm32)
-            jniCrossCompileOptions << JniCrossCompileOptions(nativeUtils.wpi.platforms.linuxarm64)
-            sources {
-                cpp {
-                    source {
-                        srcDirs 'apriltag'
-                        include 'AprilTagJNI.cpp'
-                    }
-                    exportedHeaders {
-                        srcDirs 'apriltag'
-                        include '**/*.h'
-                    }
-                }
-            }
-            binaries.all {
-                lib library: 'apriltag', linkage: 'shared'
-            }
         }
     }
 }

--- a/config.gradle
+++ b/config.gradle
@@ -7,11 +7,6 @@ nativeUtils.withCrossLinuxArm64()
 nativeUtils {
   wpi {
     configureDependencies {
-      wpiVersion = "-1"
-      niLibVersion = "2020.10.1"
-      opencvVersion = "3.4.7-3"
-    //   googleTestVersion = "1.9.0-4-437e100-1"
-      imguiVersion = "1.76-2"
     }
   }
 }

--- a/publish.gradle
+++ b/publish.gradle
@@ -11,13 +11,13 @@ publishing {
     }
 }
 
-def releaseNumber = 1
+def releaseNumber = 2
 
 def pubVersion = "1.11.0-$releaseNumber"
 
-def baseArtifactId = 'apriltag'
+def baseArtifactId = 'apriltaglib'
 def artifactGroupId = 'edu.wpi.first.thirdparty.frc2023'
-def zipBaseName = '_GROUP_edu_wpi_first_thirdparty_frc2023_ID_apriltag_CLS'
+def zipBaseName = '_GROUP_edu_wpi_first_thirdparty_frc2023_ID_apriltaglib_CLS'
 
 def outputsFolder = file("$project.buildDir/outputs")
 
@@ -82,7 +82,7 @@ addTaskToCopyAllOutputs(cSourcesZip)
 
 model {
     publishing {
-        def gTaskList = createComponentZipTasks($.components, ['apriltag', 'apriltagjni'], zipBaseName, Zip, project, includeStandardZipFormat)
+        def gTaskList = createComponentZipTasks($.components, ['apriltaglib'], zipBaseName, Zip, project, includeStandardZipFormat)
         publications {
             c(MavenPublication) {
                 gTaskList.each {

--- a/publish.gradle
+++ b/publish.gradle
@@ -72,6 +72,10 @@ task cHeadersZip(type: Zip) {
         into '/'
         include "*.h"
     }
+    from('apriltag/common/') {
+        include "*.h"
+        into '/common'
+    }
 }
 
 build.dependsOn cHeadersZip


### PR DESCRIPTION
JNI is going to be included in wpilib. WPILib will ship an apriltag library. That will statically link to this library. So this library both does not need to be named in a normal way, and only needs to ship statically